### PR TITLE
Upgrade to jclouds 1.8.1

### DIFF
--- a/bundles/target/pom.xml
+++ b/bundles/target/pom.xml
@@ -18,6 +18,10 @@
       <developerConnection>scm:git:git@github.com:disy/jSCSI.git</developerConnection>
    </scm>
 
+   <properties>
+      <jclouds.version>1.8.1</jclouds.version>
+   </properties>
+
    <profiles>
       <profile>
          <activation>
@@ -98,17 +102,17 @@
       <dependency>
          <groupId>org.apache.jclouds</groupId>
          <artifactId>jclouds-blobstore</artifactId>
-         <version>1.7.0</version>
+         <version>${jclouds.version}</version>
       </dependency>
       <dependency>
          <groupId>org.apache.jclouds.provider</groupId>
          <artifactId>aws-s3</artifactId>
-         <version>1.7.0</version>
+         <version>${jclouds.version}</version>
       </dependency>
       <dependency>
          <groupId>org.apache.jclouds.api</groupId>
          <artifactId>filesystem</artifactId>
-         <version>1.7.0</version>
+         <version>${jclouds.version}</version>
       </dependency>
       <dependency>
          <groupId>org.osgi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>15.0</version>
+			<version>17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>


### PR DESCRIPTION
These releases include many fixes for a variety of aws-s3 and
filesystem issues.  It also addresses a conflict between Java 7u51 and
newer and Guava 15 and older:

https://issues.apache.org/jira/browse/JCLOUDS-427
https://code.google.com/p/guava-libraries/issues/detail?id=1635

Release notes:

https://jclouds.apache.org/releasenotes/1.7.1/
https://jclouds.apache.org/releasenotes/1.7.2/
https://jclouds.apache.org/releasenotes/1.7.3/
https://jclouds.apache.org/releasenotes/1.8.0/
https://jclouds.apache.org/releasenotes/1.8.1/