### PR TITLE
Configure assembly to concatenate services

### DIFF
--- a/bundles/target/src/main/assembly/jarAssembly.xml
+++ b/bundles/target/src/main/assembly/jarAssembly.xml
@@ -79,4 +79,9 @@
 			</includes>
 		</fileSet>
 	</fileSets>
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
 </assembly>


### PR DESCRIPTION
This allows jclouds to find both the filesystem and s3 providers.
Previously this threw:

java.util.NoSuchElementException: key [filesystem] not in the list of providers or apis: {providers=[aws-s3], apis=[s3]}